### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # haasomeapitools
-
+[![Run on Repl.it](https://repl.it/badge/github/iamcos/haasomeapitools)](https://repl.it/github/iamcos/haasomeapitools)
 
 botdatabase file execution runs iteration algorithm over around 700 mad-hatter configs that are stored in csv files alongside.
   with botdatabase is possible to load and save bots to files in json and csv or into a database.


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).